### PR TITLE
[FIX] Cannot open qrc:/assets/icons/material-icons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ qt_add_executable(${CMAKE_PROJECT_NAME}
     src/main.cpp
     i18n/i18n.qrc
     assets/assets.qrc
+    assets/icons.qrc
     qml/qml.qrc
     qml/ComponentLibrary/ComponentLibrary.qrc
 )


### PR DESCRIPTION
# Current Behavior

About a hundred (by eye) errors about  cannot open a file
```
qrc:/qml/IconSvg.qml:15:5: QML QQuickImage: Cannot open: qrc:/assets/icons/material-icons/duotone/info.svg
qrc:/qml/IconSvg.qml:15:5: QML QQuickImage: Cannot open: qrc:/assets/icons/material-icons/duotone/info.svg
qrc:/qml/IconSvg.qml:15:5: QML QQuickImage: Cannot open: qrc:/assets/icons/material-icons/duotone/tune.svg
qrc:/qml/IconSvg.qml:15:5: QML QQuickImage: Cannot open: qrc:/assets/icons/material-icons/duotone/tune.svg
```
Incorrect display of the interface

![изображение](https://github.com/emericg/QmlAppTemplate/assets/15817985/95c8f493-5ba7-4cec-8bf0-d14664b1212a)

# Expected behavior

No errors and correct display.

![изображение](https://github.com/emericg/QmlAppTemplate/assets/15817985/1af29d86-3d4c-4d84-9477-9ee421fb9b61)



